### PR TITLE
www-data instead of nginx

### DIFF
--- a/misc/logrotate.d/nginx
+++ b/misc/logrotate.d/nginx
@@ -5,7 +5,7 @@
         compress
         delaycompress
         notifempty
-        create 640 nginx adm
+        create 640 www-data adm
         sharedscripts
         postrotate
                 [ -f /run/nginx.pid ] && kill -USR1 `cat /run/nginx.pid`


### PR DESCRIPTION
Use www-data instead of nginx for logrotate.

Nginx user does not exist untill user created it. Therefore daily cron won't run properly : 

`run-parts /etc/cron.daily
error: nginx:8 unknown user 'nginx'
error: found error in /var/log/nginx/*.log , skipping
`
