### PR TITLE
Update to Openssl 1.1.0a

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ rm -rf openssl*
 
 #Download Latest nginx, nasxsi & OpenSSL, then extract.
 latest_nginx=$(curl -L http://nginx.org/en/download.html | egrep -o "nginx\-[0-9.]+\.tar[.a-z]*" | head -n 1)
-(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0.tar.gz" && tar -xaf "openssl-1.1.0.tar.gz") &
+(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0a.tar.gz" && tar -xaf "openssl-1.1.0a.tar.gz") &
 (curl -fLRO "http://nginx.org/download/${latest_nginx}" && tar -xaf "${latest_nginx}") &
 
 


### PR DESCRIPTION
OpenSSL 1.1.0 users should upgrade to 1.1.0a

https://marc.ttias.be/openssl-announce/2016-09/msg00005.php

Built and tested. Works fine
