### PR TITLE
Update to Openssl 1.1.0a

### DIFF
--- a/ansible.sh
+++ b/ansible.sh
@@ -10,7 +10,7 @@ rm -rf openssl*
 
 #Download Latest nginx, nasxsi & OpenSSL, then extract.
 latest_nginx=$(curl -L http://nginx.org/en/download.html | egrep -o "nginx\-[0-9.]+\.tar[.a-z]*" | head -n 1)
-(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0.tar.gz" && tar -xaf "openssl-1.1.0.tar.gz") &
+(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0a.tar.gz" && tar -xaf "openssl-1.1.0a.tar.gz") &
 (curl -fLRO "http://nginx.org/download/${latest_nginx}" && tar -xaf "${latest_nginx}") &
 wait
 
@@ -18,7 +18,7 @@ wait
 rm /usr/src/*.tar.gz
 
 #Patch OpenSSL
-latest_openssl=$(echo openssl-1.1.0*)
+latest_openssl=$(echo openssl-1.1.0a*)
 cd "${latest_openssl}"
 
 


### PR DESCRIPTION
OpenSSL 1.1.0 users should upgrade to 1.1.0a

https://marc.ttias.be/openssl-announce/2016-09/msg00005.php

Built and tested. Works fine
