### PR TITLE
Update to OpenSSL 1.1.0b

### DIFF
--- a/ansible.sh
+++ b/ansible.sh
@@ -10,7 +10,7 @@ rm -rf openssl*
 
 #Download Latest nginx, nasxsi & OpenSSL, then extract.
 latest_nginx=$(curl -L http://nginx.org/en/download.html | egrep -o "nginx\-[0-9.]+\.tar[.a-z]*" | head -n 1)
-(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0a.tar.gz" && tar -xaf "openssl-1.1.0a.tar.gz") &
+(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0a.tar.gz" && tar -xaf "openssl-1.1.0b.tar.gz") &
 (curl -fLRO "http://nginx.org/download/${latest_nginx}" && tar -xaf "${latest_nginx}") &
 wait
 

--- a/ansible.sh
+++ b/ansible.sh
@@ -10,7 +10,7 @@ rm -rf openssl*
 
 #Download Latest nginx, nasxsi & OpenSSL, then extract.
 latest_nginx=$(curl -L http://nginx.org/en/download.html | egrep -o "nginx\-[0-9.]+\.tar[.a-z]*" | head -n 1)
-(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0a.tar.gz" && tar -xaf "openssl-1.1.0b.tar.gz") &
+(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0b.tar.gz" && tar -xaf "openssl-1.1.0b.tar.gz") &
 (curl -fLRO "http://nginx.org/download/${latest_nginx}" && tar -xaf "${latest_nginx}") &
 wait
 

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ rm -rf openssl*
 
 #Download Latest nginx, nasxsi & OpenSSL, then extract.
 latest_nginx=$(curl -L http://nginx.org/en/download.html | egrep -o "nginx\-[0-9.]+\.tar[.a-z]*" | head -n 1)
-(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0a.tar.gz" && tar -xaf "openssl-1.1.0a.tar.gz") &
+(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0a.tar.gz" && tar -xaf "openssl-1.1.0b.tar.gz") &
 (curl -fLRO "http://nginx.org/download/${latest_nginx}" && tar -xaf "${latest_nginx}") &
 
 

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ rm -rf openssl*
 
 #Download Latest nginx, nasxsi & OpenSSL, then extract.
 latest_nginx=$(curl -L http://nginx.org/en/download.html | egrep -o "nginx\-[0-9.]+\.tar[.a-z]*" | head -n 1)
-(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0a.tar.gz" && tar -xaf "openssl-1.1.0b.tar.gz") &
+(curl -fLRO "https://www.openssl.org/source/openssl-1.1.0b.tar.gz" && tar -xaf "openssl-1.1.0b.tar.gz") &
 (curl -fLRO "http://nginx.org/download/${latest_nginx}" && tar -xaf "${latest_nginx}") &
 
 


### PR DESCRIPTION
Major changes between OpenSSL 1.1.0a and OpenSSL 1.1.0b [26 Sep 2016]
- Fix Use After Free for large message sizes (CVE-2016-6309)

**CVE-2016-6309 (OpenSSL advisory)  [Critical severity] 26th September 2016:** 
This issue only affects OpenSSL 1.1.0a, released on 22nd September 2016. The patch applied to address CVE-2016-6307 resulted in an issue where if a message larger than approx 16k is received then the underlying buffer to store the incoming message is reallocated and moved. Unfortunately a dangling pointer to the old location is left which results in an attempt to write to the previously freed location. This is likely to result in a crash, however it could potentially lead to execution of arbitrary code. Reported by Robert Święcki (Google Security Team).
