### PR TITLE
Add support for nginx headers more module

### DIFF
--- a/ansible.sh
+++ b/ansible.sh
@@ -11,8 +11,8 @@ rm -rf openssl*
 #Download Latest nginx, nasxsi & OpenSSL, then extract.
 latest_nginx=$(curl -L http://nginx.org/en/download.html | egrep -o "nginx\-[0-9.]+\.tar[.a-z]*" | head -n 1)
 (curl -fLRO "https://www.openssl.org/source/openssl-1.1.0e.tar.gz" && tar -xaf "openssl-1.1.0e.tar.gz") &
-
 (curl -fLRO "http://nginx.org/download/${latest_nginx}" && tar -xaf "${latest_nginx}") &
+(curl -fLRO "https://github.com/openresty/headers-more-nginx-module/archive/v0.32.tar.gz" && tar -xaf "v0.32.tar.gz") &
 wait
 
 #Cleaning
@@ -58,6 +58,7 @@ patch -p1 < nginx__dynamic_tls_records_1.11.5*.patch
 --with-threads \
 --with-http_ssl_module \
 --with-http_geoip_module \
+--add-module=../headers-more-nginx-module-0.32 \
 --with-openssl=/usr/src/${latest_openssl} \
 --with-ld-opt=-lrt \
 

--- a/build.sh
+++ b/build.sh
@@ -48,8 +48,8 @@ rm -rf openssl*
 #Download Latest nginx, nasxsi & OpenSSL, then extract.
 latest_nginx=$(curl -L http://nginx.org/en/download.html | egrep -o "nginx\-[0-9.]+\.tar[.a-z]*" | head -n 1)
 (curl -fLRO "https://www.openssl.org/source/openssl-1.1.0e.tar.gz" && tar -xaf "openssl-1.1.0e.tar.gz") &
-
 (curl -fLRO "http://nginx.org/download/${latest_nginx}" && tar -xaf "${latest_nginx}") &
+(curl -fLRO "https://github.com/openresty/headers-more-nginx-module/archive/v0.32.tar.gz" && tar -xaf "v0.32.tar.gz") &
 
 
 #Download Naxsi if wanted
@@ -103,6 +103,7 @@ $ngx_http2 \
 --with-threads \
 --with-http_ssl_module \
 --with-http_geoip_module \
+--add-module=../headers-more-nginx-module-0.32 \
 --with-openssl=/usr/src/${latest_openssl} \
 --with-ld-opt=-lrt \
 


### PR DESCRIPTION
Because of the way nginx configuration inheritance model works, if you set headers at one level (for example, in server section) and then at a lower level (let's say location) you set some other headers, then the first headers will discarded. You can read more about this [here](https://github.com/yandex/gixy/blob/master/docs/en/plugins/addheaderredefinition.md)

To solve this issue you either can 
- duplicate important headers;
- set all headers at one level (server section is a good choice)
- use ngx_headers_more module.

Using the ngx_headers is the best option to keep the nginx vhosts configuration files clean without duplicating the same headers again and again

Check the nginx headers more module [documentation](https://github.com/openresty/headers-more-nginx-module#description)

